### PR TITLE
fix: replace bare except clauses with specific exception types

### DIFF
--- a/dashboard/data_service.py
+++ b/dashboard/data_service.py
@@ -28,7 +28,7 @@ class DashboardService:
             else:
                 kp = Keypair.from_base58_string(pk_str)
             return str(kp.pubkey())
-        except:
+        except Exception:
             return "Unknown"
 
     def get_wallet_balance(self):
@@ -56,7 +56,7 @@ class DashboardService:
         try:
             with open("best_meme_strategy.json", "r") as f:
                 return json.load(f)
-        except:
+        except (FileNotFoundError, json.JSONDecodeError):
             return {"formula": "Not Trained Yet"}
 
     def get_market_overview(self, limit=50):
@@ -70,7 +70,7 @@ class DashboardService:
         """
         try:
             return pd.read_sql(query, self.engine)
-        except:
+        except Exception:
             return pd.DataFrame()
     
     def get_recent_logs(self, n=50):

--- a/lord/experiment.py
+++ b/lord/experiment.py
@@ -196,7 +196,7 @@ def train_run(args, train_frac, decay_type, decay_val, device):
     
     for step in pbar:
         try: x, y = next(iter_loader)
-        except: iter_loader = iter(train_loader); x, y = next(iter_loader)
+        except StopIteration: iter_loader = iter(train_loader); x, y = next(iter_loader)
         x, y = x.to(device), y.to(device)
         
         logits = model(x)

--- a/times.py
+++ b/times.py
@@ -114,7 +114,7 @@ class DataEngine:
                 # 自动判断是基金还是指数
                 try:
                     df = self.pro.fund_daily(ts_code=INDEX_CODE, start_date=START_DATE, end_date=TEST_END_DATE)
-                except:
+                except Exception:
                     df = self.pro.index_daily(ts_code=INDEX_CODE, start_date=START_DATE, end_date=TEST_END_DATE)
 
             if df is None or df.empty:


### PR DESCRIPTION
## Problem

5 bare `except:` clauses catch `BaseException` including `SystemExit` and `KeyboardInterrupt`.

## Changes

| File | Exception | Rationale |
|------|-----------|-----------|
| `dashboard/data_service.py:31` | `Exception` | Keypair parsing |
| `dashboard/data_service.py:59` | `(FileNotFoundError, json.JSONDecodeError)` | Strategy file loading |
| `dashboard/data_service.py:73` | `Exception` | SQL query fallback |
| `lord/experiment.py:199` | `StopIteration` | DataLoader iterator exhaustion |
| `times.py:117` | `Exception` | API call fallback (fund_daily → index_daily) |