### PR TITLE
fix: harden AlphaGPT data and execution correctness

### DIFF
--- a/data_pipeline/config.py
+++ b/data_pipeline/config.py
@@ -16,6 +16,8 @@ class Config:
     MIN_FDV = 10000000.0            
     MAX_FDV = float('inf') 
     BIRDEYE_API_KEY = os.getenv("BIRDEYE_API_KEY", "")
+    BIRDEYE_BASE_URL = os.getenv("BIRDEYE_BASE_URL", "https://public-api.birdeye.so")
+    BASE_URL = BIRDEYE_BASE_URL
     BIRDEYE_IS_PAID = True
     USE_DEXSCREENER = False
     CONCURRENCY = 20

--- a/data_pipeline/data_manager.py
+++ b/data_pipeline/data_manager.py
@@ -51,7 +51,12 @@ class DataManager:
         async with aiohttp.ClientSession(headers=self.birdeye.headers) as session:
             tasks = []
             for t in selected_tokens:
-                tasks.append(self.birdeye.get_token_history(session, t['address']))
+                tasks.append(self.birdeye.get_token_history(
+                    session,
+                    t['address'],
+                    liquidity=t.get('liquidity'),
+                    fdv=t.get('fdv'),
+                ))
             
             batch_size = 20
             total_candles = 0

--- a/data_pipeline/fetcher.py
+++ b/data_pipeline/fetcher.py
@@ -14,7 +14,7 @@ class BirdeyeFetcher:
         self.semaphore = asyncio.Semaphore(5)
 
     async def get_trending_tokens(self, limit=100):
-        url = f"{Config.BASE_URL}/defi/token_trending?sort_by=rank&sort_type=asc&offset=0&limit={limit}"
+        url = f"{Config.BIRDEYE_BASE_URL}/defi/token_trending?sort_by=rank&sort_type=asc&offset=0&limit={limit}"
         async with aiohttp.ClientSession(headers=self.headers) as session:
             try:
                 async with session.get(url) as resp:
@@ -34,7 +34,7 @@ class BirdeyeFetcher:
         time_to = int(datetime.now().timestamp())
         time_from = int((datetime.now() - timedelta(days=days)).timestamp())
         
-        url = f"{Config.BASE_URL}/defi/ohlcv"
+        url = f"{Config.BIRDEYE_BASE_URL}/defi/ohlcv"
         params = {
             "address": address,
             "type": Config.TIMEFRAME,

--- a/data_pipeline/providers/base.py
+++ b/data_pipeline/providers/base.py
@@ -6,5 +6,5 @@ class DataProvider(ABC):
         pass
 
     @abstractmethod
-    async def get_token_history(self, session, address: str, days: int):
+    async def get_token_history(self, session, address: str, days: int, **kwargs):
         pass

--- a/data_pipeline/providers/birdeye.py
+++ b/data_pipeline/providers/birdeye.py
@@ -7,12 +7,21 @@ from .base import DataProvider
 
 class BirdeyeProvider(DataProvider):
     def __init__(self):
-        self.base_url = "https://public-api.birdeye.so"
+        self.base_url = Config.BIRDEYE_BASE_URL
         self.headers = {
             "X-API-KEY": Config.BIRDEYE_API_KEY,
             "accept": "application/json"
         }
         self.semaphore = asyncio.Semaphore(Config.CONCURRENCY)
+
+    @staticmethod
+    def _as_float(value, default=0.0):
+        try:
+            if value is None:
+                return default
+            return float(value)
+        except (TypeError, ValueError):
+            return default
         
     async def get_trending_tokens(self, limit=100):
         url = f"{self.base_url}/defi/token_trending"
@@ -37,8 +46,8 @@ class BirdeyeProvider(DataProvider):
                                 'symbol': t.get('symbol', 'UNKNOWN'),
                                 'name': t.get('name', 'UNKNOWN'),
                                 'decimals': t.get('decimals', 6),
-                                'liquidity': t.get('liquidity', 0),
-                                'fdv': t.get('fdv', 0)
+                                'liquidity': self._as_float(t.get('liquidity')),
+                                'fdv': self._as_float(t.get('fdv'))
                             })
                         return results
                     else:
@@ -48,9 +57,11 @@ class BirdeyeProvider(DataProvider):
                 logger.error(f"Birdeye Trending Exception: {e}")
                 return []
 
-    async def get_token_history(self, session, address, days=Config.HISTORY_DAYS):
+    async def get_token_history(self, session, address, days=Config.HISTORY_DAYS, liquidity=None, fdv=None):
         time_to = int(datetime.now().timestamp())
         time_from = int((datetime.now() - timedelta(days=days)).timestamp())
+        snapshot_liquidity = self._as_float(liquidity)
+        snapshot_fdv = self._as_float(fdv)
         
         url = f"{self.base_url}/defi/ohlcv"
         params = {
@@ -70,6 +81,8 @@ class BirdeyeProvider(DataProvider):
                         
                         formatted = []
                         for item in items:
+                            candle_liquidity = self._as_float(item.get('liquidity'), snapshot_liquidity)
+                            candle_fdv = self._as_float(item.get('fdv'), snapshot_fdv)
                             formatted.append((
                                 datetime.fromtimestamp(item['unixTime']), # time
                                 address,                                  # address
@@ -78,15 +91,15 @@ class BirdeyeProvider(DataProvider):
                                 float(item['l']),                         # low
                                 float(item['c']),                         # close
                                 float(item['v']),                         # volume
-                                0.0,                                      # liquidity
-                                0.0,                                      # fdv
+                                candle_liquidity,                         # liquidity
+                                candle_fdv,                               # fdv
                                 'birdeye'                                 # source
                             ))
                         return formatted
                     elif resp.status == 429:
                         logger.warning(f"Birdeye 429 for {address}, retrying...")
                         await asyncio.sleep(2)
-                        return await self.get_token_history(session, address, days)
+                        return await self.get_token_history(session, address, days, liquidity=liquidity, fdv=fdv)
                     else:
                         return []
             except Exception as e:

--- a/execution/config.py
+++ b/execution/config.py
@@ -1,23 +1,14 @@
+import json
 import os
 from dotenv import load_dotenv
 from solders.keypair import Keypair
-import base58
 
 load_dotenv()
 
 class ExecutionConfig:
     RPC_URL = os.getenv("QUICKNODE_RPC_URL", "填入RPC地址")
     _PRIV_KEY_STR = os.getenv("SOLANA_PRIVATE_KEY", "")
-
-    if not _PRIV_KEY_STR:
-        raise ValueError("Missing SOLANA_PRIVATE_KEY in .env")
-    try:
-        PAYER_KEYPAIR = Keypair.from_base58_string(_PRIV_KEY_STR)
-    except Exception:
-        import json
-        PAYER_KEYPAIR = Keypair.from_bytes(json.loads(_PRIV_KEY_STR))
-
-    WALLET_ADDRESS = str(PAYER_KEYPAIR.pubkey())
+    _PAYER_KEYPAIR = None
 
     DEFAULT_SLIPPAGE_BPS = 200 # bps
     
@@ -25,3 +16,23 @@ class ExecutionConfig:
     
     SOL_MINT = "So11111111111111111111111111111111111111112"
     USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+
+    @classmethod
+    def has_private_key(cls):
+        return bool(cls._PRIV_KEY_STR)
+
+    @classmethod
+    def get_payer_keypair(cls):
+        if cls._PAYER_KEYPAIR is not None:
+            return cls._PAYER_KEYPAIR
+        if not cls._PRIV_KEY_STR:
+            raise ValueError("Missing SOLANA_PRIVATE_KEY in .env")
+        try:
+            cls._PAYER_KEYPAIR = Keypair.from_base58_string(cls._PRIV_KEY_STR)
+        except Exception:
+            cls._PAYER_KEYPAIR = Keypair.from_bytes(json.loads(cls._PRIV_KEY_STR))
+        return cls._PAYER_KEYPAIR
+
+    @classmethod
+    def get_wallet_address(cls):
+        return str(cls.get_payer_keypair().pubkey())

--- a/execution/jupiter.py
+++ b/execution/jupiter.py
@@ -1,6 +1,5 @@
 import aiohttp
 import base64
-import json
 from loguru import logger
 from solders.transaction import VersionedTransaction
 from .config import ExecutionConfig
@@ -39,7 +38,7 @@ class JupiterAggregator:
         url = f"{self.base_url}/swap"
         payload = {
             "quoteResponse": quote_response,
-            "userPublicKey": ExecutionConfig.WALLET_ADDRESS,
+            "userPublicKey": ExecutionConfig.get_wallet_address(),
             "wrapAndUnwrapSol": True,
             "computeUnitPriceMicroLamports": "auto",
             "prioritizationFeeLamports": "auto"
@@ -61,7 +60,7 @@ class JupiterAggregator:
         try:
             tx_bytes = base64.b64decode(b64_tx_str)
             txn = VersionedTransaction.from_bytes(tx_bytes)
-            signature = ExecutionConfig.PAYER_KEYPAIR.sign_message(txn.message.to_bytes())
+            signature = ExecutionConfig.get_payer_keypair().sign_message(txn.message.to_bytes())
             txn = VersionedTransaction.populate(txn.message, [signature])
             return txn
         except Exception as e:

--- a/execution/rpc_handler.py
+++ b/execution/rpc_handler.py
@@ -9,7 +9,7 @@ class QuickNodeClient:
 
     async def get_balance(self):
         try:
-            resp = await self.client.get_balance(ExecutionConfig.PAYER_KEYPAIR.pubkey())
+            resp = await self.client.get_balance(ExecutionConfig.get_payer_keypair().pubkey())
             return resp.value / 1e9
         except Exception as e:
             logger.error(f"Failed to get balance: {e}")

--- a/execution/trader.py
+++ b/execution/trader.py
@@ -9,6 +9,7 @@ from .jupiter import JupiterAggregator
 
 class SolanaTrader:
     def __init__(self):
+        self.config = ExecutionConfig
         self.rpc = QuickNodeClient()
         self.jup = JupiterAggregator()
         self.is_running = True
@@ -50,7 +51,7 @@ class SolanaTrader:
         logger.info(f"Executing SELL: {percentage*100}% of {token_address} -> SOL")
         raw_balance = 0
         try:
-            wallet_pubkey = Pubkey.from_string(ExecutionConfig.WALLET_ADDRESS)
+            wallet_pubkey = Pubkey.from_string(ExecutionConfig.get_wallet_address())
             mint_pubkey = Pubkey.from_string(token_address)
             opts = TokenAccountOpts(
                 program_id=self.TOKEN_PROGRAM_ID,

--- a/model_core/alphagpt.py
+++ b/model_core/alphagpt.py
@@ -2,7 +2,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from .config import ModelConfig
-from .ops import OPS_CONFIG
+from .vocab import FORMULA_VOCAB
 
 
 class NewtonSchulzLowRankDecay:
@@ -222,11 +222,11 @@ class AlphaGPT(nn.Module):
     def __init__(self):
         super().__init__()
         self.d_model = 64
-        self.features_list = ['RET', 'VOL', 'V_CHG', 'PV', 'TREND']
-        self.ops_list = [cfg[0] for cfg in OPS_CONFIG]
+        self.features_list = list(FORMULA_VOCAB.feature_names)
+        self.ops_list = list(FORMULA_VOCAB.operator_names)
         
-        self.vocab = self.features_list + self.ops_list
-        self.vocab_size = len(self.vocab)
+        self.vocab = list(FORMULA_VOCAB.token_names)
+        self.vocab_size = FORMULA_VOCAB.size
         
         # Embedding
         self.token_emb = nn.Embedding(self.vocab_size, self.d_model)

--- a/model_core/config.py
+++ b/model_core/config.py
@@ -1,5 +1,6 @@
 import torch
 import os
+from .vocab import FORMULA_VOCAB
 
 class ModelConfig:
     DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -10,4 +11,4 @@ class ModelConfig:
     TRADE_SIZE_USD = 1000.0
     MIN_LIQUIDITY = 5000.0 # 低于此流动性视为归零/无法交易
     BASE_FEE = 0.005 # 基础费率 0.5% (Swap + Gas + Jito Tip)
-    INPUT_DIM = 6
+    INPUT_DIM = FORMULA_VOCAB.feature_count

--- a/model_core/data_loader.py
+++ b/model_core/data_loader.py
@@ -10,6 +10,7 @@ class CryptoDataLoader:
         self.feat_tensor = None
         self.raw_data_cache = None
         self.target_ret = None
+        self.addresses = []
         
     def load_data(self, limit_tokens=500):
         print("Loading data from SQL...")
@@ -17,9 +18,9 @@ class CryptoDataLoader:
         SELECT address FROM tokens 
         LIMIT {limit_tokens} 
         """
-        addrs = pd.read_sql(top_query, self.engine)['address'].tolist()
-        if not addrs: raise ValueError("No tokens found.")
-        addr_str = "'" + "','".join(addrs) + "'"
+        self.addresses = pd.read_sql(top_query, self.engine)['address'].tolist()
+        if not self.addresses: raise ValueError("No tokens found.")
+        addr_str = "'" + "','".join(self.addresses) + "'"
         data_query = f"""
         SELECT time, address, open, high, low, close, volume, liquidity, fdv
         FROM ohlcv
@@ -29,6 +30,7 @@ class CryptoDataLoader:
         df = pd.read_sql(data_query, self.engine)
         def to_tensor(col):
             pivot = df.pivot(index='time', columns='address', values=col)
+            pivot = pivot.reindex(columns=self.addresses)
             pivot = pivot.fillna(method='ffill').fillna(0.0)
             return torch.tensor(pivot.values.T, dtype=torch.float32, device=ModelConfig.DEVICE)
         self.raw_data_cache = {

--- a/model_core/factors.py
+++ b/model_core/factors.py
@@ -1,6 +1,8 @@
 import torch
 import torch.nn as nn
 
+from .vocab import FEATURE_NAMES
+
 
 class RMSNormFactor(nn.Module):
     """RMSNorm for factor normalization"""
@@ -154,7 +156,7 @@ class AdvancedFactorEngineer:
 
 
 class FeatureEngineer:
-    INPUT_DIM = 6
+    INPUT_DIM = len(FEATURE_NAMES)
 
     @staticmethod
     def compute_features(raw_dict):

--- a/model_core/vm.py
+++ b/model_core/vm.py
@@ -1,10 +1,10 @@
 import torch
 from .ops import OPS_CONFIG
-from .factors import FeatureEngineer
+from .vocab import FORMULA_VOCAB
 
 class StackVM:
     def __init__(self):
-        self.feat_offset = FeatureEngineer.INPUT_DIM
+        self.feat_offset = FORMULA_VOCAB.operator_offset
         self.op_map = {i + self.feat_offset: cfg[1] for i, cfg in enumerate(OPS_CONFIG)}
         self.arity_map = {i + self.feat_offset: cfg[2] for i, cfg in enumerate(OPS_CONFIG)}
 
@@ -14,6 +14,8 @@ class StackVM:
             for token in formula_tokens:
                 token = int(token)
                 if token < self.feat_offset:
+                    if token >= feat_tensor.shape[1]:
+                        return None
                     stack.append(feat_tensor[:, token, :])
                 elif token in self.op_map:
                     arity = self.arity_map[token]

--- a/model_core/vocab.py
+++ b/model_core/vocab.py
@@ -1,0 +1,41 @@
+from dataclasses import dataclass
+
+from .ops import OPS_CONFIG
+
+
+FEATURE_NAMES = (
+    "RET",
+    "LIQ_SCORE",
+    "PRESSURE",
+    "FOMO",
+    "DEV",
+    "LOG_VOL",
+)
+
+
+@dataclass(frozen=True)
+class FormulaVocab:
+    feature_names: tuple[str, ...]
+    operator_names: tuple[str, ...]
+
+    @property
+    def feature_count(self) -> int:
+        return len(self.feature_names)
+
+    @property
+    def operator_offset(self) -> int:
+        return self.feature_count
+
+    @property
+    def token_names(self) -> tuple[str, ...]:
+        return self.feature_names + self.operator_names
+
+    @property
+    def size(self) -> int:
+        return len(self.token_names)
+
+
+FORMULA_VOCAB = FormulaVocab(
+    feature_names=FEATURE_NAMES,
+    operator_names=tuple(cfg[0] for cfg in OPS_CONFIG),
+)

--- a/strategy_manager/runner.py
+++ b/strategy_manager/runner.py
@@ -1,9 +1,9 @@
 import asyncio
 import torch
 import json
+import os
 import time
 from loguru import logger
-import pandas as pd
 
 from data_pipeline.data_manager import DataManager
 from model_core.vm import StackVM
@@ -25,6 +25,7 @@ class StrategyRunner:
         self.loader = CryptoDataLoader()
         self.token_map = {} # {address: tensor_index} 用于快速查找特征
         self.last_scan_time = 0
+        self.stop_signal_path = os.getenv("STOP_SIGNAL_PATH", "STOP_SIGNAL")
         
         try:
             with open("best_meme_strategy.json", "r") as f:
@@ -46,6 +47,9 @@ class StrategyRunner:
         
         while True:
             try:
+                if self._handle_stop_signal():
+                    break
+
                 loop_start = time.time()
                 
                 if time.time() - self.last_scan_time > 900: # 15 min
@@ -56,7 +60,13 @@ class StrategyRunner:
                 self.loader.load_data(limit_tokens=300)
                 await self._build_token_mapping()
 
+                if self._handle_stop_signal():
+                    break
+
                 await self.monitor_positions()
+
+                if self._handle_stop_signal():
+                    break
                 
                 if self.portfolio.get_open_count() < StrategyConfig.MAX_OPEN_POSITIONS:
                     await self.scan_for_entries()
@@ -72,18 +82,29 @@ class StrategyRunner:
                 logger.exception(f"Global Loop Error: {e}")
                 await asyncio.sleep(30)
 
+    def _stop_requested(self):
+        if not os.path.exists(self.stop_signal_path):
+            return False
+        try:
+            with open(self.stop_signal_path, "r") as f:
+                signal = f.read().strip().upper()
+        except OSError:
+            return True
+        return signal in {"", "STOP", "STOPPED"}
+
+    def _handle_stop_signal(self):
+        if not self._stop_requested():
+            return False
+        logger.warning(f"STOP signal received from {self.stop_signal_path}. Trading loop will stop.")
+        try:
+            with open(self.stop_signal_path, "w") as f:
+                f.write("STOPPED")
+        except OSError as e:
+            logger.warning(f"Failed to mark stop signal as consumed: {e}")
+        return True
+
     async def _build_token_mapping(self):
-        query = f"""
-        SELECT address, count(*) as cnt 
-        FROM ohlcv 
-        GROUP BY address 
-        ORDER BY cnt DESC 
-        LIMIT 300
-        """
-        df = pd.read_sql(query, self.loader.engine)
-        addresses = df['address'].tolist()
-        
-        self.token_map = {addr: idx for idx, addr in enumerate(addresses)}
+        self.token_map = {addr: idx for idx, addr in enumerate(self.loader.addresses)}
         logger.info(f"Mapped {len(self.token_map)} tokens for inference.")
 
     async def monitor_positions(self):
@@ -128,6 +149,9 @@ class StrategyRunner:
                     await self._execute_sell(token_addr, 1.0, "AI_Signal")
 
     async def scan_for_entries(self):
+        if self._handle_stop_signal():
+            return
+
         raw_signals = self.vm.execute(self.formula, self.loader.feat_tensor)
         
         if raw_signals is None: return
@@ -162,6 +186,8 @@ class StrategyRunner:
             
             is_safe = await self.risk.check_safety(token_addr, liq_usd)
             if is_safe:
+                if self._handle_stop_signal():
+                    return
                 await self._execute_buy(token_addr, score)
                 
                 # 检查仓位上限
@@ -169,6 +195,10 @@ class StrategyRunner:
                     break
 
     async def _execute_buy(self, token_addr, score):
+        if self._handle_stop_signal():
+            logger.warning("Buy skipped because STOP signal is active.")
+            return
+
         balance = await self.trader.rpc.get_balance()
         amount_sol = self.risk.calculate_position_size(balance)
         
@@ -212,6 +242,10 @@ class StrategyRunner:
             logger.success(f"+ | Position Added: {token_amount_ui:.2f} units @ {entry_price_sol:.6f} SOL")
 
     async def _execute_sell(self, token_addr, ratio, reason):
+        if self._handle_stop_signal():
+            logger.warning("Sell skipped because STOP signal is active.")
+            return
+
         pos = self.portfolio.positions.get(token_addr)
         if not pos: return
 
@@ -282,4 +316,6 @@ if __name__ == "__main__":
         loop.run_until_complete(runner.initialize())
         loop.run_until_complete(runner.run_loop())
     except KeyboardInterrupt:
+        pass
+    finally:
         loop.run_until_complete(runner.shutdown())


### PR DESCRIPTION
## Summary

This PR collects a focused set of correctness fixes from the forked AlphaGPT branch. It addresses formula-token interpretation, Birdeye ingestion metadata, runner signal/address mapping, dashboard stop handling, and execution credential import behavior.

## Related Fork Issues

- https://github.com/itscheems/AlphaGPT/issues/1
- https://github.com/itscheems/AlphaGPT/issues/2
- https://github.com/itscheems/AlphaGPT/issues/3
- https://github.com/itscheems/AlphaGPT/issues/4
- https://github.com/itscheems/AlphaGPT/issues/5
- https://github.com/itscheems/AlphaGPT/issues/6

## Changes

- Add a shared formula vocabulary so AlphaGPT, FeatureEngineer, ModelConfig, and StackVM use the same feature/operator token boundary.
- Preserve Birdeye liquidity/fdv metadata during OHLCV ingestion and fix the legacy fetcher base URL reference.
- Reuse the loader's tensor row address order in the strategy runner to avoid signal/address mismatches.
- Wire dashboard `STOP_SIGNAL` handling into the runner loop and trade-entry points.
- Defer Solana private-key parsing until execution paths actually need wallet credentials.

## Validation

- [x] `python3 -m compileall -q .`
- [x] Merged fork-main smoke check

Validation details: ran validation on a detached worktree at `itscheems/AlphaGPT@main`. The smoke check verified shared formula feature count, AlphaGPT vocab size alignment, StackVM `[0, 1, 6]` execution as feature0 + feature1, and that `ExecutionConfig` imports without `SOLANA_PRIVATE_KEY` while still raising on credential access.

## Risk / Impact

- Existing saved formulas generated with the old inconsistent token boundary may not preserve intended semantics.
- Liquidity/fdv are snapshot-level values unless Birdeye provides candle-level values.
- `STOP_SIGNAL` now blocks both buys and sells; if risk-reducing sells should remain allowed during stop, that should be specified separately.
