### PR TITLE
修复 README 中失效的 Star History 图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=imbue-bit/AlphaGPT&type=date&legend=top-left)](https://www.star-history.com/#imbue-bit/AlphaGPT&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=imbue-bit/AlphaGPT&type=date&legend=top-left)](https://star-history.dera.page/#imbue-bit/AlphaGPT&type=date&legend=top-left)


### PR DESCRIPTION
项目 README 里的 Star History 图表目前无法正常显示，原因是 GitHub 的 stargazer API 限制。本 PR 将图表切换到可正常工作的地址，恢复仓库的 Star 趋势图，方便读者直观了解项目的关注度变化。